### PR TITLE
Remove "All rights reserved from copyright headers"

### DIFF
--- a/examples/include/test_composition/debounce.h
+++ b/examples/include/test_composition/debounce.h
@@ -2,7 +2,7 @@
  * @file      debounce.h
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-12-4
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  *   
  * @brief   Simple implementation that uses time measurement and avoids setting a value when some arbitrary time hasn't
  * elapsed.

--- a/examples/include/test_composition/publisher.h
+++ b/examples/include/test_composition/publisher.h
@@ -2,7 +2,7 @@
  * @file      static_registry.cc
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-11-26
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  *   
  * @brief   
  *

--- a/examples/include/test_composition/subscriber.h
+++ b/examples/include/test_composition/subscriber.h
@@ -2,7 +2,7 @@
  * @file      subscriber.h
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-11-26
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  *   
  * @brief   
  *

--- a/examples/src/manual_composition.cc
+++ b/examples/src/manual_composition.cc
@@ -2,7 +2,7 @@
  * @file      manual_composition.cc
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-11-26
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  *   
  * @brief   
  *

--- a/examples/src/publisher.cc
+++ b/examples/src/publisher.cc
@@ -2,7 +2,7 @@
  * @file      publisher.cc
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-11-26
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  *   
  * @brief   
  *

--- a/examples/src/subscriber.cc
+++ b/examples/src/subscriber.cc
@@ -2,7 +2,7 @@
  * @file      subscriber.cc
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-11-26
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  *   
  * @brief   
  *

--- a/examples/test/debounce_tests.cc
+++ b/examples/test/debounce_tests.cc
@@ -2,7 +2,7 @@
  * @file      debounce_tests.cc
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-12-4
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  * @brief   
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/test/main.cc
+++ b/examples/test/main.cc
@@ -2,7 +2,7 @@
  * @file      debounce_tests.cc
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-12-4
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  * @brief   
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/test/pub_sub_tests.cc
+++ b/examples/test/pub_sub_tests.cc
@@ -2,7 +2,7 @@
  * @file      main.cc
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-12-4
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  * 
  * @brief   Unit tests for the Publisher and Subscriber classes.
  *

--- a/tools/cmake/test_tools_add_doubles.cmake
+++ b/tools/cmake/test_tools_add_doubles.cmake
@@ -1,25 +1,19 @@
 # @file      test_tools_add_doubles.cmake
 # @author    Sławomir Cielepak (sie@spyro-soft.com)
 # @date      2024-11-25
-# @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+# @copyright Copyright (c) 2024 Beam Limited.
 
-# @license   Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+# @license Licensed under the Apache License, Version 2.0 (the "License");
+#          you may not use this file except in compliance with the License.
+#          You may obtain a copy of the License at
+#         
+#              http://www.apache.org/licenses/LICENSE-2.0
+#         
+#          Unless required by applicable law or agreed to in writing, software
+#          distributed under the License is distributed on an "AS IS" BASIS,
+#          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#          See the License for the specific language governing permissions and
+#          limitations under the License.
 
 # @details This macro creates a test doubles library with mocked ROS 2 rclcpp layer.
 #          It is used to create a library that can be used in integration tests

--- a/tools/include/test_tools_ros/create_timer_mock.h
+++ b/tools/include/test_tools_ros/create_timer_mock.h
@@ -2,7 +2,7 @@
  * @file      create_timer_mock.h
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-11-26
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  *
  * @brief     Mock header for timer creation functionality.
  *

--- a/tools/include/test_tools_ros/includes_mock.h
+++ b/tools/include/test_tools_ros/includes_mock.h
@@ -2,7 +2,7 @@
  * @file      includes_mock.h
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-11-21
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  *  
  * @brief    Mock header for ROS 2 tools.
  *

--- a/tools/include/test_tools_ros/logger_mock.h
+++ b/tools/include/test_tools_ros/logger_mock.h
@@ -2,7 +2,7 @@
  * @file      logger_mock.h
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-11-18
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  *  
  * @brief    Mock header for ROS 2 logging.
  *

--- a/tools/include/test_tools_ros/publisher_mock.h
+++ b/tools/include/test_tools_ros/publisher_mock.h
@@ -2,7 +2,7 @@
  * @file      publisher_mock.h
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-11-26
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
   *  
  * @brief     Mock header for ROS 2 Publisher.
  *

--- a/tools/include/test_tools_ros/ros_extensions.h
+++ b/tools/include/test_tools_ros/ros_extensions.h
@@ -4,7 +4,7 @@
  * @date       7 Feb 2019
  * @author     Magnus Maynard
  *
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  *  
  * @brief    extensions for waiting for messages and conditions
  *

--- a/tools/include/test_tools_ros/single_instance.h
+++ b/tools/include/test_tools_ros/single_instance.h
@@ -2,7 +2,7 @@
  * @file      single_instance.h
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-11-26
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  *  
  * @brief    Mock header for ROS 2 single instance class. 
  *

--- a/tools/include/test_tools_ros/static_registry.h
+++ b/tools/include/test_tools_ros/static_registry.h
@@ -2,7 +2,7 @@
  * @file      static_registry.h
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-11-26
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
   *  
  * @brief     Mock header for ROS 2 static registry.
  *

--- a/tools/include/test_tools_ros/subscription_mock.h
+++ b/tools/include/test_tools_ros/subscription_mock.h
@@ -2,7 +2,7 @@
  * @file      subscription_mock.h
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-11-26
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
   *  
  * @brief     Mock header for ROS 2 Subscriber.
  *

--- a/tools/include/test_tools_ros/test_clock.h
+++ b/tools/include/test_tools_ros/test_clock.h
@@ -2,7 +2,7 @@
  * @file      test_clock.h
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-12-2
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
   *  
  * @brief     ROS2 test clock utility.
  *

--- a/tools/src/logger_mock.cc
+++ b/tools/src/logger_mock.cc
@@ -2,7 +2,7 @@
  * @file      logger_mock.cc
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-11-18
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  *   
  * @brief     Mock implementation for ROS 2 logging.
  *

--- a/tools/src/static_registry.cc
+++ b/tools/src/static_registry.cc
@@ -2,7 +2,7 @@
  * @file      static_registry.cc
  * @author    Sławomir Cielepak (sie@spyro-soft.com)
  * @date      2024-11-26
- * @copyright Copyright (c) 2024 Beam Limited. All rights reserved.
+ * @copyright Copyright (c) 2024 Beam Limited.
  *   
  * @brief    Mock implementation for ROS 2 static registry.
  *


### PR DESCRIPTION
Remove license-incompatible statement "All right reserved" from copyright headers.