### PR TITLE
Fix build and example

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -45,15 +45,13 @@ else()
   )
 endif()
 
-target_link_libraries(common PRIVATE GTest::gmock)
-
 
 ament_target_dependencies(common
-  PUBLIC rclcpp #gmock_vendor
+  PUBLIC rclcpp gmock_vendor
 )
 
 ament_export_dependencies(
-  rclcpp #gmock_vendor
+  rclcpp gmock_vendor
 )
 
 


### PR DESCRIPTION
The current example "test_tools_ros_examples" is failing:

The following tests FAILED:
	  1 - test_tools_ros_examples-test (Failed)
Errors while running CTest
Output from these tests are in: /home/mua/spyrosoft/ros2_ws/build/test_tools_ros_examples/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.


To reproduce, call:
colcon build && colcon test --packages-select test_tools_ros_examples --event-handlers console_cohesion+
