### PR TITLE
Fix repo URL for License badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![RTEST Logo](rtest/doc/logo.png)
 
-[![Licence](https://img.shields.io/github/license/Ileriayo/markdown-badges?style=for-the-badge)](./LICENSE)
+[![Licence](https://img.shields.io/github/license/Beam-and-Spyrosoft/rtest?style=for-the-badge)](./LICENSE)
 
 [![ROS 2 Jazzy CI](https://github.com/Beam-and-Spyrosoft/rtest/actions/workflows/ros2-pull-request.yml/badge.svg?branch=main)](https://github.com/Beam-and-Spyrosoft/rtest/actions/workflows/ros2-pull-request.yml)
 


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/b51ca25d-28c8-49b8-890d-cb64634205df)

After:
![image](https://github.com/user-attachments/assets/bddd3d9f-c9da-47c3-9728-356b0f3e4565)
