### PR TITLE
Fix clang build: remove invalid template keyword usage

### DIFF
--- a/rtest/include/rtest/service_client_mock.hpp
+++ b/rtest/include/rtest/service_client_mock.hpp
@@ -193,7 +193,7 @@ public:
   void post_init_setup()
   {
     rtest::StaticMocksRegistry::instance().template registerServiceClient<ServiceT>(
-      fully_qualified_name_, service_name_, this->template weak_from_this());
+      fully_qualified_name_, service_name_, this->weak_from_this());
   }
 
 private:

--- a/rtest/include/rtest/service_mock.hpp
+++ b/rtest/include/rtest/service_mock.hpp
@@ -137,7 +137,7 @@ public:
   void post_init_setup()
   {
     rtest::StaticMocksRegistry::instance().template registerService<ServiceT>(
-      fully_qualified_name_, service_name_, this->template weak_from_this());
+      fully_qualified_name_, service_name_, this->weak_from_this());
   }
 
   std::shared_ptr<void> create_request() override


### PR DESCRIPTION
## Summary
Clang 19.1.1 fails to build this project with the following error:
```
error: 'weak_from_this' following the 'template' keyword does not refer to a template
  140 |       fully_qualified_name_, service_name_, this->template weak_from_this());
      |                                                   ~~~~~~~~ ^
```

This PR removes the unnecessary template keyword from calls to weak_from_this(), since weak_from_this() is not a templated method and the keyword doesn’t belong there.
For reference, GCC 13.3.0 builds the project successfully both before and after this change, but Clang rightfully enforces the C++ standard and flags this as an error.

## Impact
 - No changes to runtime behavior or logic.
 - Improves cross-compiler compatibility (Clang & GCC).
 - Safer for future maintenance and CI portability.