### PR TITLE
Add MockRegistryCleaner utility to reset StaticMocksRegistry

### DIFF
--- a/rtest/CMakeLists.txt
+++ b/rtest/CMakeLists.txt
@@ -62,6 +62,7 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 add_library(rtest_common SHARED
   src/static_registry.cpp
   src/logger_mock.cpp
+  src/registry_cleaner.cpp
 )
 add_library(${PROJECT_NAME}::rtest_common ALIAS rtest_common)
 set_property(TARGET rtest_common PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/rtest/include/rtest/registry_cleaner.hpp
+++ b/rtest/include/rtest/registry_cleaner.hpp
@@ -1,0 +1,31 @@
+// Copyright 2025 Spyrosoft Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// @file      registry_cleaner.hpp
+// @date      2025-06-21
+
+#pragma once
+#include <gtest/gtest.h>
+
+namespace rtest
+{
+/**
+ * Listens to Google-Test events and wipes the static mock registry
+ * after each test-suite finishes.
+ */
+class MockRegistryCleaner final : public ::testing::EmptyTestEventListener
+{
+  void OnTestSuiteEnd(const ::testing::TestSuite &) override;
+};
+}  // namespace rtest

--- a/rtest/include/rtest/static_registry.hpp
+++ b/rtest/include/rtest/static_registry.hpp
@@ -32,6 +32,7 @@
 #include <boost/type_index.hpp>
 
 #include <rtest/single_instance.hpp>
+#include <rtest/registry_cleaner.hpp>
 
 namespace rclcpp
 {
@@ -429,8 +430,25 @@ public:
       lazy_init_action_servers_.end());
   }
 
+  void reset()
+  {
+    publishersRegistry_.clear();
+    subscriptionsRegistry_.clear();
+    timersRegistry_.clear();
+    servicesRegistry_.clear();
+    serviceClientsRegistry_.clear();
+    actionServersRegistry_.clear();
+    actionClientsRegistry_.clear();
+    mockRegistry_.clear();
+    lazy_init_action_clients_.clear();
+    lazy_init_action_servers_.clear();
+  }
+
 private:
-  StaticMocksRegistry() {}
+  StaticMocksRegistry()
+  {
+    ::testing::UnitTest::GetInstance()->listeners().Append(new MockRegistryCleaner());
+  }
 
   static StaticMocksRegistry theRegistry_;
 

--- a/rtest/src/registry_cleaner.cpp
+++ b/rtest/src/registry_cleaner.cpp
@@ -1,0 +1,27 @@
+// Copyright 2025 Beam Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// @file      registry_cleaner.cpp
+// @date      2025-06-21
+
+#include "rtest/registry_cleaner.hpp"
+#include "rtest/static_registry.hpp"
+
+namespace rtest
+{
+void MockRegistryCleaner::OnTestSuiteEnd(const ::testing::TestSuite &)
+{
+  StaticMocksRegistry::instance().reset();
+}
+}  // namespace rtest


### PR DESCRIPTION
This PR introduces a new GTest event listener `MockRegistryCleaner` and a corresponding `reset()` API on `StaticMocksRegistry` so that every test suite runs with a clean mock registry. 
It also wires the new files into CMake so they’re built and exported alongside `rtest_common`.

Fixes #41
