### PR TITLE
Add wait_for_service to ServiceClientMock

### DIFF
--- a/rtest/include/rtest/service_client_mock.hpp
+++ b/rtest/include/rtest/service_client_mock.hpp
@@ -195,9 +195,10 @@ public:
   {
     auto mock = rtest::StaticMocksRegistry::instance().getMock(this).lock();
     if (mock) {
-      return std::static_pointer_cast<rtest::ServiceClientMock<ServiceT>>(mock)->wait_for_service(timeout);
+      return std::static_pointer_cast<rtest::ServiceClientMock<ServiceT>>(mock)->wait_for_service(
+        timeout);
     }
-    return true;
+    return false;
   }
 
   void post_init_setup()


### PR DESCRIPTION
The `ServiceClientMock` currently supports the `service_is_ready` function, but not the `wait_for_service` function.
I added the `wait_for_service` function to the mock.

For more info see the [rclcpp documentation](https://docs.ros2.org/beta3/api/rclcpp/classrclcpp_1_1client_1_1ClientBase.html#a2999c323a3ee4935cd74d12675e668a0).