### PR TITLE
Add auto linking of GTest::gmock target

### DIFF
--- a/rtest/cmake/test_tools_add_doubles.cmake
+++ b/rtest/cmake/test_tools_add_doubles.cmake
@@ -88,6 +88,7 @@ function(test_tools_add_doubles target)
 
     target_link_libraries(${LIB_DOUBLES_NAME} INTERFACE
       ${arg_AMENT_DEPENDENCIES}
+      GTest::gmock
     )
   else()
     get_target_property(TARGET_SOURCES ${target} SOURCES)
@@ -114,6 +115,7 @@ function(test_tools_add_doubles target)
 
     target_link_libraries(${LIB_DOUBLES_NAME}
       ${arg_AMENT_DEPENDENCIES}
+      GTest::gmock
     )
   endif()
   


### PR DESCRIPTION
Added automatic linking with Gmock lib to overcome potential issues described in #91 